### PR TITLE
Makefile: Modify 'all' target for supporting 'make' to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ TIEM_INSTALL_PREFIX = ${PREFIX}/tiem
 include Makefile.common
 
 .PHONY: all clean test gotest gotool help
-all:
-	build
+all: build
 
 # 1. build binary
 build:


### PR DESCRIPTION
## What problem does this PR solve?
Issue Number: close #xxx

Problem Summary: When using "make" to build project，it will get error:  **make build: no such file or dir**

## What is changed and how it works?
Proposal: xxx

What's Changed:

Modify Makefile's 'all' target

How it works:

## Check List
Tests
 - [x] Unit test
 - [ ] Integration test
 - [ ] Manual test (add detailed scripts or steps below)
 - [ ] No code

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility
- [ ] Documentation

 Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility